### PR TITLE
better error message if user doesnt configure diff3

### DIFF
--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -14,7 +14,7 @@ function! mergetool#start() "{{{
   " If file does not have conflict markers, it's a wrong target for mergetool
   if !s:has_conflict_markers()
     echohl WarningMsg
-    echo 'File does not have conflict markers'
+    echo 'File does not have conflict markers (must be diff3 style)'
     echohl None
     return
   endif


### PR DESCRIPTION
I'm just making this suggestion to the error message because I think it is likely that a user will NOT be using diff3, since it is not the default. Yes, this is in the README, and I personally read that first, but since the README is rather long, and contains more than just optional configuration information, it is very likely that the user will jump-in before they reach that part, and get very confused by an error message that says they have no conflict markers, when they're looking at a file that very clearly has error markers (just not the right kind).