### PR TITLE
`let g:mergetool_use_tab = 0` to use current tab instead of creating new

### DIFF
--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -45,7 +45,9 @@ function! mergetool#start() "{{{
 
   " Open in new tab, do not break existing layout
   if !s:run_as_git_mergetool
-    tab split
+     if get(g:, "mergetool_use_tab", 1)
+         tab split
+     endif
   endif
 
   let g:mergetool_in_merge_mode = 1
@@ -104,7 +106,11 @@ function! mergetool#stop() " {{{
     endif
 
     let g:mergetool_in_merge_mode = 0
-    tabclose
+    if get(g:, "mergetool_use_tab", 1)
+        tabclose
+    else
+        only
+    endif
   endif
 endfunction " }}}
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,12 @@ Alternatively, you can start with `local` or `unmodified` revision, and change y
 
 ### Layout
 
+`vim-mergetool` defaults to create new tab for merging, if you don't want new tab to be created, set
+
+```vim
+let g:mergetool_use_tab = 0
+```
+
 `vim-mergetool` defaults to two vertical splits layout with `MERGED` file on the left, and `remote` revision on the right. `MERGED` file is processed according to `g:mergetool_prefer_revision` setting as described above.
 
 ```vim


### PR DESCRIPTION
`let g:mergetool_use_tab = 0` to use current tab instead of creating new

fix https://github.com/samoshkin/vim-mergetool/issues/6