### PR TITLE
Simplify interface: hide irrelevant commands when not merging

### DIFF
--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -52,7 +52,24 @@ function! mergetool#start() "{{{
 
   call mergetool#prefer_revision(g:mergetool_prefer_revision)
   call mergetool#set_layout(g:mergetool_layout)
+  call mergetool#bind_commands()
 endfunction "}}}
+
+function! mergetool#bind_commands()
+  command! -nargs=0 MergetoolStop call mergetool#stop()
+  command! -nargs=1 MergetoolSetLayout call mergetool#set_layout(<f-args>)
+  command! -nargs=1 MergetoolToggleLayout call mergetool#toggle_layout(<f-args>)
+  command! -nargs=0 MergetoolPreferLocal call mergetool#prefer_revision('local')
+  command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
+endf
+
+function! mergetool#unbind_commands()
+  delcommand MergetoolStop
+  delcommand MergetoolSetLayout
+  delcommand MergetoolToggleLayout
+  delcommand MergetoolPreferLocal
+  delcommand MergetoolPreferRemote
+endf
 
 " Stop mergetool effect depends on:
 " - when run as 'git mergetool'
@@ -104,6 +121,7 @@ function! mergetool#stop() " {{{
     endif
 
     let g:mergetool_in_merge_mode = 0
+    call mergetool#unbind_commands()
     tabclose
   endif
 endfunction " }}}

--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -223,6 +223,57 @@ endfunction " }}}
 
 " }}}
 
+" Diff exchange {{{ 
+
+" Do either diffget or diffput, depending on given direction
+" and whether the window has adjacent window in a given direction
+" h|<left> + window on right = diffget from right win
+" h|<left> + no window on right = diffput to left win
+" l|<right> + window on left = diffget from left win
+" l|<right> + no window on left = diffput to right win
+" Same logic applies for vertical directions: 'j' and 'k'
+
+let s:directions = {
+      \ 'h': 'l',
+      \ 'l': 'h',
+      \ 'j': 'k',
+      \ 'k': 'j' }
+
+function mergetool#DiffExchange(dir)
+  let oppdir = s:directions[a:dir]
+
+  let winoppdir = s:FindWindowOnDir(oppdir)
+  if (winoppdir != -1)
+    execute "diffget " . winbufnr(winoppdir)
+  else
+    let windir = s:FindWindowOnDir(a:dir)
+    if (windir != -1)
+      execute "diffput " . winbufnr(windir)
+    else
+      echohl WarningMsg
+      echo 'Cannot exchange diff. Found only single window'
+      echohl None
+    endif
+  endif
+endfunction
+
+" Finds window in given direction and returns it win number
+" If no window found, returns -1
+function s:FindWindowOnDir(dir)
+  let oldwin = winnr()
+
+  execute "noautocmd wincmd " . a:dir
+  let curwin = winnr()
+  if (oldwin != curwin)
+    noautocmd wincmd p
+    return curwin
+  else
+    return -1
+  endif
+endfunction
+
+" }}}
+
 " Private functions{{{
 
 let s:markers = {

--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -61,6 +61,7 @@ function! mergetool#bind_commands()
   command! -nargs=1 MergetoolToggleLayout call mergetool#toggle_layout(<f-args>)
   command! -nargs=0 MergetoolPreferLocal call mergetool#prefer_revision('local')
   command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
+  doautocmd User MergetoolStart
 endf
 
 function! mergetool#unbind_commands()
@@ -69,7 +70,15 @@ function! mergetool#unbind_commands()
   delcommand MergetoolToggleLayout
   delcommand MergetoolPreferLocal
   delcommand MergetoolPreferRemote
+  doautocmd User MergetoolStop
 endf
+
+" Dummy autocmds to prevent errors.
+augroup mergetool_dummy
+  au!
+  autocmd User MergetoolStart let s:mergetool_dummy = 1
+  autocmd User MergetoolStop let s:mergetool_dummy = 0
+augroup END
 
 " Stop mergetool effect depends on:
 " - when run as 'git mergetool'

--- a/plugin/mergetool.vim
+++ b/plugin/mergetool.vim
@@ -7,6 +7,7 @@ let g:loaded_mergetool = 1
 
 let g:mergetool_in_merge_mode = 0
 
+" Commands and <plug> mappings for mergetool state
 command! -nargs=0 MergetoolStart call mergetool#start()
 command! -nargs=0 MergetoolStop call mergetool#stop()
 command! -nargs=0 MergetoolToggle call mergetool#toggle()
@@ -17,64 +18,17 @@ command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
 
 nnoremap <silent> <Plug>(MergetoolToggle) :<C-u>call mergetool#toggle()<CR>
 
-" {{{ Diff exchange
 
-" Do either diffget or diffput, depending on given direction
-" and whether the window has adjacent window in a given direction
-" h|<left> + window on right = diffget from right win
-" h|<left> + no window on right = diffput to left win
-" l|<right> + window on left = diffget from left win
-" l|<right> + no window on left = diffput to right win
-" Same logic applies for vertical directions: 'j' and 'k'
-
-let s:directions = {
-      \ 'h': 'l',
-      \ 'l': 'h',
-      \ 'j': 'k',
-      \ 'k': 'j' }
-
-function s:DiffExchange(dir)
-  let oppdir = s:directions[a:dir]
-
-  let winoppdir = s:FindWindowOnDir(oppdir)
-  if (winoppdir != -1)
-    execute "diffget " . winbufnr(winoppdir)
-  else
-    let windir = s:FindWindowOnDir(a:dir)
-    if (windir != -1)
-      execute "diffput " . winbufnr(windir)
-    else
-      echohl WarningMsg
-      echo 'Cannot exchange diff. Found only single window'
-      echohl None
-    endif
-  endif
-endfunction
-
-" Finds window in given direction and returns it win number
-" If no window found, returns -1
-function s:FindWindowOnDir(dir)
-  let oldwin = winnr()
-
-  execute "noautocmd wincmd " . a:dir
-  let curwin = winnr()
-  if (oldwin != curwin)
-    noautocmd wincmd p
-    return curwin
-  else
-    return -1
-  endif
-endfunction
 
 " Commands and <plug> mappings for diff exchange commands
-command! -nargs=0 MergetoolDiffExchangeLeft call s:DiffExchange('h')
-command! -nargs=0 MergetoolDiffExchangeRight call s:DiffExchange('l')
-command! -nargs=0 MergetoolDiffExchangeDown call s:DiffExchange('j')
-command! -nargs=0 MergetoolDiffExchangeUp call s:DiffExchange('k')
+command! -nargs=0 MergetoolDiffExchangeLeft call mergetool#DiffExchange('h')
+command! -nargs=0 MergetoolDiffExchangeRight call mergetool#DiffExchange('l')
+command! -nargs=0 MergetoolDiffExchangeDown call mergetool#DiffExchange('j')
+command! -nargs=0 MergetoolDiffExchangeUp call mergetool#DiffExchange('k')
 
-nnoremap <silent> <Plug>(MergetoolDiffExchangeLeft) :<C-u>call <SID>DiffExchange('h')<CR>
-nnoremap <silent> <Plug>(MergetoolDiffExchangeRight) :<C-u>call <SID>DiffExchange('l')<CR>
-nnoremap <silent> <Plug>(MergetoolDiffExchangeDown) :<C-u>call <SID>DiffExchange('j')<CR>
-nnoremap <silent> <Plug>(MergetoolDiffExchangeUp) :<C-u>call <SID>DiffExchange('k')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeLeft) :<C-u>call mergetool#DiffExchange('h')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeRight) :<C-u>call mergetool#DiffExchange('l')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeDown) :<C-u>call mergetool#DiffExchange('j')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeUp) :<C-u>call mergetool#DiffExchange('k')<CR>
 
 " }}}

--- a/plugin/mergetool.vim
+++ b/plugin/mergetool.vim
@@ -7,20 +7,17 @@ let g:loaded_mergetool = 1
 
 let g:mergetool_in_merge_mode = 0
 
-" Commands and <plug> mappings for mergetool state
+" Commands and <plug> mappings for mergetool state. Additional commands
+" available during merging.
 command! -nargs=0 MergetoolStart call mergetool#start()
-command! -nargs=0 MergetoolStop call mergetool#stop()
 command! -nargs=0 MergetoolToggle call mergetool#toggle()
-command! -nargs=1 MergetoolSetLayout call mergetool#set_layout(<f-args>)
-command! -nargs=1 MergetoolToggleLayout call mergetool#toggle_layout(<f-args>)
-command! -nargs=0 MergetoolPreferLocal call mergetool#prefer_revision('local')
-command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
 
 nnoremap <silent> <Plug>(MergetoolToggle) :<C-u>call mergetool#toggle()<CR>
 
 
 
-" Commands and <plug> mappings for diff exchange commands
+" Commands and <plug> mappings for diff exchange commands. These can be used
+" outside of merging (in any diff windows).
 command! -nargs=0 MergetoolDiffExchangeLeft call mergetool#DiffExchange('h')
 command! -nargs=0 MergetoolDiffExchangeRight call mergetool#DiffExchange('l')
 command! -nargs=0 MergetoolDiffExchangeDown call mergetool#DiffExchange('j')

--- a/readme.md
+++ b/readme.md
@@ -383,6 +383,18 @@ let g:airline_section_z = airline#section#create(['_diffmerge', ...other_parts])
 
 ![Status line indicator](./screenshots/airline_merge_indicator.png)
 
+
+You can run vimscript when mergemode begins and ends:
+
+```vim
+augroup your_mergetool
+  au!
+  autocmd User MergetoolStart set nospell
+  autocmd User MergetoolStop set spell
+augroup END
+```
+
+
 ### Quitting merge mode
 
 When exiting merge mode, `vim-mergetool` would prompt you whether merge was successful. If not, it will rollback changes to the buffer, will not save `MERGED` file to disk, and exit with non-zero code, when running as a `git mergetool`.


### PR DESCRIPTION
I find tab completion or `:Unite command` gets cluttered with the myriad of merge commands, so I made this change to slim down the possibilities to what's relevant.

It doesn't make sense to adjust our layout unless we're merging, so only define these commands while merge is active. This makes it easier to find the right mergetool commands.

I didn't touch the diff exchange commands because it looks like they're useful in non diff merges, so they are valid outside of merging.

Allow users to define their own Mergetool commands while merge is active. Since we're hiding commands outside of merge, users should be able to do the same.

See [how I use it here in my config](
https://github.com/idbrii/daveconfig/blob/a9cff6b/multi/vim/after/plugin/after_scm.vim#L8-L14).

Some useful examples of aliases:

```
command! MergetoolDiffWithRemote MergetoolToggleLayout rlm
command! MergetoolThreeWay MergetoolToggleLayout LmR
```

I also moved the diffexchange code to autoload.