### PR TITLE
Make merged file hidden while changing layout

### DIFF
--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -149,6 +149,11 @@ function! mergetool#set_layout(layout) " {{{
     let l:_winstate = winsaveview()
   endif
 
+  " Ensure merged file (which likely has unsaved conflict removal changes) can
+  " be hidden without error.
+  let bufhidden_bak = getbufvar(s:mergedfile_bufnr, '&bufhidden')
+  call setbufvar(s:mergedfile_bufnr, '&bufhidden', 'hide')
+
   " Before changing layout, turn off diff mode in all visible windows
   windo diffoff
 
@@ -198,6 +203,7 @@ function! mergetool#set_layout(layout) " {{{
   if s:goto_win_with_merged_file() && exists('l:_winstate')
     call winrestview(l:_winstate)
   endif
+  call setbufvar(s:mergedfile_bufnr, '&bufhidden', bufhidden_bak)
 endfunction " }}}
 
 " Toggles between given and default layout


### PR DESCRIPTION
Fix #12: We were assuming users had 'hidden' set.

mergetool#start ends with two steps: prefer_revision and set_layout.
prefer_revision modifies the current buffer to remove conflict markers.
set_layout closes all but the first window in g:mergetool_layout and
then shows the other windows in order.

If a user has these combination of settings, closing the merge buffer's
window will trigger an error:
    set nohidden
    let g:mergetool_layout = 'rm'

We modify the merge buffer (without saving it -- so the user knows we
made changes) and then we try to close it (because 'm' is not the first
item in mergetool_layout), which triggers an "unsaved changes" error.

Prevent the error by temporarily marking the merge buffer to hide while
we're modifying the layout.

Uses setbufvar (introduced to vim in 7.0) to clean up so if the user
doesn't include 'm' in the layout, we don't fail to clean up. And in
that case, the merge buffer is already hidden, so it doesn't cause
unsaved errors until it's shown again.