### PR TITLE
Support using as git-mergetool on win32

### DIFF
--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -243,7 +243,13 @@ function! s:load_revision(revision)
     call s:remove_conflict_markers(a:revision)
     setlocal nomodifiable readonly buftype=nofile bufhidden=delete nobuflisted
     execute "setlocal filetype=" . s:mergedfile_filetype
-    execute "file " . a:revision
+    let bufname = a:revision
+    if s:run_as_git_mergetool && has('win32')
+      " Cannot create a buffer called 'remote' if there's already one called
+      " 'REMOTE' because win32 is not case-sensitive.
+      let bufname .= '_derived'
+    endif
+    execute "file " . bufname
   elseif a:revision ==# 'BASE' || a:revision ==# 'REMOTE' || a:revision ==# 'LOCAL'
 
     " First, if run as 'git mergetool', try find buffer by name: 'BASE|REMOTE|LOCAL'


### PR DESCRIPTION
Fix buffer already exists error on win32.

Cannot create a buffer called 'remote' if there's already one called
'REMOTE' because win32 is not case-sensitive. When we use as
git-mergetool, there's always buffers called BASE, LOCAL, and REMOTE. So
append a suffix to disambiguate. These buffers are derived by removing
conflicts from the merge file, so I call them _derived.