### PR TITLE
Create vimdoc from readme

### DIFF
--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -52,7 +52,24 @@ function! mergetool#start() "{{{
 
   call mergetool#prefer_revision(g:mergetool_prefer_revision)
   call mergetool#set_layout(g:mergetool_layout)
+  call mergetool#bind_commands()
 endfunction "}}}
+
+function! mergetool#bind_commands()
+  command! -nargs=0 MergetoolStop call mergetool#stop()
+  command! -nargs=1 MergetoolSetLayout call mergetool#set_layout(<f-args>)
+  command! -nargs=1 MergetoolToggleLayout call mergetool#toggle_layout(<f-args>)
+  command! -nargs=0 MergetoolPreferLocal call mergetool#prefer_revision('local')
+  command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
+endf
+
+function! mergetool#unbind_commands()
+  delcommand MergetoolStop
+  delcommand MergetoolSetLayout
+  delcommand MergetoolToggleLayout
+  delcommand MergetoolPreferLocal
+  delcommand MergetoolPreferRemote
+endf
 
 " Stop mergetool effect depends on:
 " - when run as 'git mergetool'
@@ -104,6 +121,7 @@ function! mergetool#stop() " {{{
     endif
 
     let g:mergetool_in_merge_mode = 0
+    call mergetool#unbind_commands()
     tabclose
   endif
 endfunction " }}}

--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -223,6 +223,57 @@ endfunction " }}}
 
 " }}}
 
+" Diff exchange {{{ 
+
+" Do either diffget or diffput, depending on given direction
+" and whether the window has adjacent window in a given direction
+" h|<left> + window on right = diffget from right win
+" h|<left> + no window on right = diffput to left win
+" l|<right> + window on left = diffget from left win
+" l|<right> + no window on left = diffput to right win
+" Same logic applies for vertical directions: 'j' and 'k'
+
+let s:directions = {
+      \ 'h': 'l',
+      \ 'l': 'h',
+      \ 'j': 'k',
+      \ 'k': 'j' }
+
+function mergetool#DiffExchange(dir)
+  let oppdir = s:directions[a:dir]
+
+  let winoppdir = s:FindWindowOnDir(oppdir)
+  if (winoppdir != -1)
+    execute "diffget " . winbufnr(winoppdir)
+  else
+    let windir = s:FindWindowOnDir(a:dir)
+    if (windir != -1)
+      execute "diffput " . winbufnr(windir)
+    else
+      echohl WarningMsg
+      echo 'Cannot exchange diff. Found only single window'
+      echohl None
+    endif
+  endif
+endfunction
+
+" Finds window in given direction and returns it win number
+" If no window found, returns -1
+function s:FindWindowOnDir(dir)
+  let oldwin = winnr()
+
+  execute "noautocmd wincmd " . a:dir
+  let curwin = winnr()
+  if (oldwin != curwin)
+    noautocmd wincmd p
+    return curwin
+  else
+    return -1
+  endif
+endfunction
+
+" }}}
+
 " Private functions{{{
 
 let s:markers = {

--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -327,7 +327,13 @@ function! s:load_revision(revision)
     call s:remove_conflict_markers(a:revision)
     setlocal nomodifiable readonly buftype=nofile bufhidden=delete nobuflisted
     execute "setlocal filetype=" . s:mergedfile_filetype
-    execute "file " . a:revision
+    let bufname = a:revision
+    if s:run_as_git_mergetool && has('win32')
+      " Cannot create a buffer called 'remote' if there's already one called
+      " 'REMOTE' because win32 is not case-sensitive.
+      let bufname .= '_derived'
+    endif
+    execute "file " . bufname
   elseif a:revision ==# 'BASE' || a:revision ==# 'REMOTE' || a:revision ==# 'LOCAL'
 
     " First, if run as 'git mergetool', try find buffer by name: 'BASE|REMOTE|LOCAL'

--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -61,6 +61,7 @@ function! mergetool#bind_commands()
   command! -nargs=1 MergetoolToggleLayout call mergetool#toggle_layout(<f-args>)
   command! -nargs=0 MergetoolPreferLocal call mergetool#prefer_revision('local')
   command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
+  doautocmd User MergetoolStart
 endf
 
 function! mergetool#unbind_commands()
@@ -69,7 +70,15 @@ function! mergetool#unbind_commands()
   delcommand MergetoolToggleLayout
   delcommand MergetoolPreferLocal
   delcommand MergetoolPreferRemote
+  doautocmd User MergetoolStop
 endf
+
+" Dummy autocmds to prevent errors.
+augroup mergetool_dummy
+  au!
+  autocmd User MergetoolStart let s:mergetool_dummy = 1
+  autocmd User MergetoolStop let s:mergetool_dummy = 0
+augroup END
 
 " Stop mergetool effect depends on:
 " - when run as 'git mergetool'

--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -176,6 +176,11 @@ function! mergetool#set_layout(layout) " {{{
     let l:_winstate = winsaveview()
   endif
 
+  " Ensure merged file (which likely has unsaved conflict removal changes) can
+  " be hidden without error.
+  let bufhidden_bak = getbufvar(s:mergedfile_bufnr, '&bufhidden')
+  call setbufvar(s:mergedfile_bufnr, '&bufhidden', 'hide')
+
   " Before changing layout, turn off diff mode in all visible windows
   windo diffoff
 
@@ -225,6 +230,7 @@ function! mergetool#set_layout(layout) " {{{
   if s:goto_win_with_merged_file() && exists('l:_winstate')
     call winrestview(l:_winstate)
   endif
+  call setbufvar(s:mergedfile_bufnr, '&bufhidden', bufhidden_bak)
 endfunction " }}}
 
 " Toggles between given and default layout

--- a/autoload/mergetool.vim
+++ b/autoload/mergetool.vim
@@ -6,6 +6,7 @@ endfunction
 let g:mergetool_layout = get(g:, 'mergetool_layout', 'mr')
 let g:mergetool_prefer_revision = get(g:, 'mergetool_prefer_revision', 'local')
 let g:MergetoolSetLayoutCallback = get(g:, 'MergetoolSetLayoutCallback', function('s:noop'))
+let g:mergetool_args_order = get(g:, 'mergetool_args_order', '')
 
 " {{{ Public exports
 
@@ -37,6 +38,16 @@ function! mergetool#start() "{{{
   let s:mergedfile_contents = join(getline(0, "$"), "\n") . "\n"
   let s:mergedfile_fileformat = &fileformat
   let s:mergedfile_filetype = &filetype
+
+  if !empty(g:mergetool_args_order)
+    let success = s:apply_args_order(s:mergedfile_bufnr, g:mergetool_args_order)
+    if !success
+      echohl WarningMsg
+      echo "g:mergetool_args_order didn't use the current file as MERGED. Ensure you're using the order as seen in :args."
+      echohl None
+      return
+    endif
+  endif
 
   " Detect if we're run as 'git mergetool' by presence of BASE|LOCAL|REMOTE buf names
   let s:run_as_git_mergetool = bufnr('BASE') != -1 &&
@@ -142,6 +153,38 @@ function! mergetool#toggle() " {{{
   else
     call mergetool#start()
   endif
+endfunction " }}}
+
+" Create hidden buffers that use git's special buffer names to support any
+" scm. We never create a MERGED buffer. Instead, return it so we can validate
+" it's as expected.
+function! s:apply_args_order(merged_bufnr, arg_order) " {{{
+  let abbrevs = {
+        \ 'M': 'MERGED',
+        \ 'B': 'BASE',
+        \ 'R': 'REMOTE',
+        \ 'L': 'LOCAL' }
+
+  let i = 1
+  for labbr in split(a:arg_order, '\zs')
+    if labbr ==# 'M'
+      let current_arg_bufnr = bufnr(argv(i - 1))
+      if a:merged_bufnr != current_arg_bufnr
+        " Fail -- input merged buffer number doesn't match arg order.
+        return 0
+      endif
+    else
+      execute 'silent' i 'argument'
+      execute 'silent file' abbrevs[labbr]
+      setlocal buftype=nofile
+      setlocal bufhidden=hide
+    endif
+    let i += 1
+  endfor
+
+  execute "buffer " . a:merged_bufnr
+  " Success
+  return 1
 endfunction " }}}
 
 " Opens set of windows with merged file and various file revisions

--- a/doc/mergetool.txt
+++ b/doc/mergetool.txt
@@ -1,0 +1,429 @@
+*mergetool.txt*  Efficient way of using Vim as a Git mergetool.
+
+License: MIT
+
+===============================================================================
+INTRO                                             *mergetool-intro*
+
+mergetool processes `MERGED` file and extracts `ours`, `theirs`, or
+`common` sides of a conflict by parsing conflict markers left by Git. Then it
+shows 2-way diff between `ours` and `theirs` versions, with raw conflict
+markers being already removed.
+
+Unlike simply comparing between `LOCAL` and `REMOTE` history revisions, it
+takes over where automatic Git merge algorithm gives up. Diffs are present
+only where Git cannot automatically resolve conflicts, and you're not
+distracted with diff highlighting of already resolved hunks.
+
+To resolve the conflict you don't need to edit conflict markers directly -
+just pick either side of a conflict using |:diffget| and |:diffput| commands.
+
+This plugin was initially inspired by https://github.com/whiteinge/diffconflicts.
+
+
+===============================================================================
+REQUIREMENTS                                      *mergetool-requirements*
+
+                                                  *mergetool-diff3*
+
+mergetool requires conflict markers in a `MERGED` file to include common
+`BASE` ancestor version as well. This is called `diff3` conflict style. >
+
+  <<<<<<< HEAD
+  ours/local revision
+  ||||||| base
+  common base revision
+  =======
+  theirs/remote revision
+  >>>>>>> feature
+
+<If you get "Conflict markers miss common base revision" error message, put the
+following in your `~/.gitconfig` to use diff3 conflict style as a default: >
+
+  [merge]
+  conflictStyle = diff3
+
+<See also
+https://git-scm.com/docs/git-config#Documentation/git-config.txt-mergeconflictStyle
+
+If something goes wrong, you can always reset conflict markers in a file to
+their initial state. It's safe to do it only during ongoing merge, otherwise
+you'd overwrite file in a working tree with version from index. >
+
+  git checkout --conflict=diff3 {file}
+
+<See also |mergetool-git-mergetool|.
+
+===============================================================================
+MAPPINGS                                          *mergetool-mappings*
+
+mergetool does not set up any key mappings for you. It justs exports a
+handful of commands and `<plug>` mappings. You're free to set up key mappings
+in your `vimrc` as you'd like. See plugin/mergetool.vim for the available
+|<Plug>| mappings.
+
+
+===============================================================================
+MERGING                                           *mergetool-merging*
+
+                                                  *:MergetoolStart*
+
+When in a file with conflicts, |:MergetoolStart| will show 2-way diff in a new
+tab with `$MERGED` file on the left. By default, all conflicts are already
+resolved by picking up `ours/LOCAL` version. You don't need to edit raw
+conflict markers manually. Either leave hunk as is, or pick `theirs/REMOTE`
+version with |:diffget| from the right, or edit hunk manually.
+
+If there's a merge in progress, |:MergetoolStart| works as usual, but Unlike
+running as a `git mergetool`, `LOCAL`, `REMOTE` and `BASE` history revisions
+are not passed from the outside. In this mode, mergetool extracts them from
+the numbered stages of Git index. >
+
+$ git cat-file -p :1:{file} > {file}.base
+$ git cat-file -p :2:{file} > {file}.local
+$ git cat-file -p :3:{file} > {file}.remote
+
+<ASSUMPTION: Therefore, it's assumed that a git merge is in progress, and
+`cwd` of running Vim instance is set to repository root dir.
+
+                                                  *:MergetoolStop*
+
+When a merge is complete, quit merge tool and ensure git gets the correct exit
+code to handle the merge correctly.
+
+When exiting merge mode, if merge was unsuccessful, mergetool discards changes
+to merged file and rollback to a buffer state as it were right before starting
+a new merge.
+
+                                                  *:MergetoolToggle*
+
+Invokes |:MergetoolStart| when no merge is active and |:MergetoolStop| when a
+merge is active. Can also be bound to a key: >
+  nmap <leader>mt <plug>(MergetoolToggle)
+<
+
+                                                  *g:mergetool_prefer_revision*
+
+|:MergetoolStart| removes conflict markers from `MERGED` file, and picks up
+`ours/local` side of a conflict by default. Use |g:mergetool_prefer_revision|
+to change the preferred side of a conflict: >
+
+  " possible values: 'local' (default), 'remote', 'base', 'unmodified'
+  let g:mergetool_prefer_revision = 'remote'
+
+<Use `unmodified` if you don't want |:MergetoolStart| to remove raw conflict
+markers from `MERGED` file.
+
+                                                  *:MergetoolPreferLocal*
+                                                  *:MergetoolPreferRemote*
+
+Alternatively, you can start with `local` or `unmodified` revision, and change
+your mind later during merge process by running :MergetoolPreferLocal or
+:MergetoolPreferRemote.
+
+### Available revisions to compare
+
+2-way diff between `local` and `remote` versions derived from conflict markers
+is a sane default, but you might want to compare `MERGED` file against other
+revisions:
+- `LOCAL`, current branch HEAD.
+- `REMOTE`, HEAD of the branch we're going to merge
+- `BASE`, common ancestor of two branches, i.e. `git merge-base branchX branchY`
+- `local`, `remote`, `base` (in lowercase), those are revisions derived from
+    `MERGED` file by picking up either side of a conflict from conflict
+    markers
+
+
+                                                  *g:mergetool_layout*
+
+mergetool defaults to two vertical splits layout with `MERGED` file on the
+left and `remote` revision on the right. `MERGED` file is processed according
+to |g:mergetool_prefer_revision|.
+
+You can customize the default layout with |g:mergetool_layout|: >
+
+  " default behaviour
+  " m - for working tree version of MERGED file
+  " r - for 'remote' revision
+  " l - for 'local' revision
+  " b - common merge 'base'
+  let g:mergetool_layout = 'mr'
+
+<Lower case letters use files derived from the merged file (by accepting that
+file's view of conflicts). To use the original `REMOTE`, `LOCAL`, `BASE` files
+from git, use uppercase characters: >
+
+  let g:mergetool_layout = 'LmR'
+
+This `LmR` setup is pretty much same to what vim-fugitive |:Gdiff|
+does, except that conflict markers are already removed. You can use
+|g:mergetool_prefer_revision|='unmodified' to replicate vim-fugitive
+completely. Indeed, mergetool is flexible enough to replicate any existing
+vim+merge solution.
+
+Vertical splits are used by default. Use a comma to split horizontally: >
+
+  " merged above remote
+  let g:mergetool_layout = 'm,r'
+  " base above local and remote above merged
+  let g:mergetool_layout = 'b,lr,m'
+<
+
+                                                  *:MergetoolToggleLayout*
+
+Use |:MergetoolToggleLayout| to switch different layouts during a merge.
+
+For example, you can default to a 2-way diff layout: >
+
+  " In 'vimrc', set your default layout.
+  let g:mergetool_layout = 'mr'
+
+<Later, during merge process: >
+
+  " View 'base' revision on the left
+  :MergetoolToggleLayout bmr
+
+  " View 'base' revision in horizontal split at the bottom
+  :MergetoolToggleLayout mr,b
+
+  " View history revisions, and hide 'MERGED' file altogether
+  :MergetoolToggleLayout LBR
+
+<In addition to commands, you can set up key mappings for your most common layouts: >
+
+  nnoremap <silent> <leader>mb :call mergetool#toggle_layout('mr,b')<CR>
+<
+
+                                                  *g:MergetoolSetLayoutCallback*
+
+To further tweak layout or change settings of individual splits, define the
+layout callback. It is called when layout is changed.
+
+Example. When layout is `mr,b`, I want the `base` horizontal split to be
+pulled of a diff mode and have syntax highlighting enabled. Also, I want it to
+reduce its height. >
+
+  function s:on_mergetool_set_layout(split)
+    if a:split["layout"] ==# 'mr,b' && a:split["split"] ==# 'b'
+      set nodiff
+      set syntax=on
+
+      resize 15
+    endif
+  endfunction
+
+  let g:MergetoolSetLayoutCallback = function('s:on_mergetool_set_layout')
+<
+
+Callback is called for each split in the layout, with a split being passed as
+a callback argument. >
+
+  {
+      'layout': 'mb,r',  # current layout
+      'split': 'b',      # current split
+      'filetype': 'vim', # file type of MERGED file
+      'bufnr': 2,        # buffer number of current split
+      'winnr': 5         # window number of current split
+  }
+
+===============================================================================
+DIFFING                                           *mergetool-diff*
+
+                                                  *:MergetoolDiffExchangeLeft*
+                                                  *:MergetoolDiffExchangeRight*
+                                                  *:MergetoolDiffExchangeDown*
+                                                  *:MergetoolDiffExchangeUp*
+
+Vim's |:diffget| and |:diffput| commands are convenient and unambiguous as
+soon as you have only two buffers in diff mode. If you prefer 3-way diff,
+you're out of lucky, as you need to explicitly tell the buffer number you want
+to exchange diff with.
+
+mergetool comes with "DiffExchange" commands and mapping, that accepts
+direction of a diff movement: "left", "right", "up", "down". You can set up
+your own key mappings for diff mode only: >
+
+  nmap <expr> <C-Left> &diff? '<Plug>(MergetoolDiffExchangeLeft)' : '<C-Left>'
+  nmap <expr> <C-Right> &diff? '<Plug>(MergetoolDiffExchangeRight)' : '<C-Right>'
+  nmap <expr> <C-Down> &diff? '<Plug>(MergetoolDiffExchangeDown)' : '<C-Down>'
+  nmap <expr> <C-Up> &diff? '<Plug>(MergetoolDiffExchangeUp)' : '<C-Up>'
+
+<Commands are available as well: >
+
+  :MergetoolDiffExchangeLeft
+  :MergetoolDiffExchangeRight
+  :MergetoolDiffExchangeDown
+  :MergetoolDiffExchangeUp
+
+<DiffExchange logic runs either |:diffget| or |:diffput| with a right
+buffer number of adjacent window, depending on:
+- given direction
+- whether window in opposite direction exists or not
+
+It's easier to explain with example.
+
+Suppose, you have 3 split layout: `MERGED` file in the middle, `base` and
+`remote` revisions are on the sides. Typically, the middle one with a `MERGED`
+file is an active split. You navigate from hunk to hunk, and decide what to do
+with a conflict: leave as is, or pick version from left/right splits.
+- `<C-Left>` would `diffget` change from the right split into the middle one.
+    If you imagine the diff movement - it goes from right to the left.
+- `<C-Right>` would `diffget` change from the left split into the middle one.
+    If you imagine the diff movement - it goes from left to the right.
+
+If the rightmost split were the active one:
+- `<C-Left>` would `diffput` change from the current split into the middle
+    one. As soon as there is no adjacent window on the right to get change
+    from, we invert `diffget` operation into `diffput`.
+- `<C-Right>` would `diffget` change from middle split.
+
+Same logic applies to "up" and "down" directions. Useful if you prefer
+horizontal splits.
+
+Conclusion~
+Despite how many splits are opened and what's the layout, you
+don't need to wrap your head around `diffput` vs `diffget` semantics, and you
+don't need to figure out correct buffer numbers manually. You just give
+desired diff movement direction, and mergetool handles the details for you.
+
+Limitations~
+* DiffExchange commands work only in normal mode, and do not
+  support visual mode and working with line ranges.
+* DiffExchange functionality is not specific to resolving merge conflicts, and
+  can be used for regular diffs.
+
+If you like `<C-arrow>` mappings from the snippet above, you might also want
+to map `<up>` and `<down>` keys to navigate diffs, instead of default `[c` and
+`]c` mappings. They're not used anyway, since you're using `h,j,k,l` for
+movements, are you? ;-) >
+
+  nnoremap <expr> <Up> &diff ? '[c' : '<Up>'
+  nnoremap <expr> <Down> &diff ? ']c' : '<Down>'
+<
+
+===============================================================================
+USER AUTOCOMMANDS                                 *mergetool-autocmd-user*
+
+                                                  *MergetoolStart-autocmd*
+                                                  *MergetoolStop-autocmd*
+
+These |User| autocommands are triggered when merge mode begins and ends. You
+could use them to turn off |spell| during a merge: >
+
+  augroup your_mergetool
+    au!
+    autocmd User MergetoolStart set nospell
+    autocmd User MergetoolStop set spell
+  augroup END
+
+<
+
+===============================================================================
+WORKING WITH OTHER PLUGINS                        *mergetool-other-plugins*
+
+                                                  *mergetool-statusline*
+                                                  *g:mergetool_in_merge_mode*
+
+|g:mergetool_in_merge_mode| indicates whether you're in merge mode. It can be
+helpful to show indicator in a status line.
+
+Example for vim-airline: >
+
+  function! AirlineDiffmergePart()
+    if get(g:, 'mergetool_in_merge_mode', 0)
+      return '↸'
+    endif
+
+    if &diff
+      return '↹'
+    endif
+
+    return ''
+  endfunction
+
+  call airline#parts#define_function('_diffmerge', 'AirlineDiffmergePart')
+  call airline#parts#define_accent('_diffmerge', 'bold')
+
+  let g:airline_section_z = airline#section#create(['_diffmerge', ...other_parts])
+<
+===============================================================================
+USING AS A MERGETOOL                              *mergetool-as-mergetool*
+                                                  *mergetool-git-mergetool*
+
+mergetool can be configured to run as a git mergetool. In your `~/.gitconfig`: >
+
+  [merge]
+  tool = vim_mergetool
+  conflictstyle = diff3
+
+  [mergetool "vim_mergetool"]
+  cmd = vim -f -c "MergetoolStart" "$MERGED" "$BASE" "$LOCAL" "$REMOTE"
+  trustExitCode = true
+
+<Git detects whether merge was successful or not in two ways:
+- When `trustExitCode = false`, checks if `MERGED` file was modified.
+- When `trustExitCode = true`, checks exit code of merge tool process.
+
+mergetool supports both options. On quit, if merge was unsuccessful, it both
+discards any unsaved changes to buffer without touching file's `ctime` and
+returns non-zero exit code.
+
+                                                  *mergetool-any-mergetool*
+                                                  *g:mergetool_args_order*
+
+If your scm doesn't use files called BASE, REMOTE, LOCAL as merge tempfiles
+(like svn), you can set the |g:mergetool_args_order| variable to tell
+mergetool which argument is which file. Setup your scm to start vim like this: >
+
+    gvim -f -c "let g:mergetool_args_order = 'MBRL'" -c "MergetoolStart" "$MERGED" "$BASE" "$REMOTE" "$LOCAL"
+
+<The@MERGED file should be the first file argument@because |:MergetoolStart| is only
+valid in a file with conflict markers.
+
+Your scm likely has its own variable names for these filenames. Check your
+documentation.
+
+For example, with TortoiseSVN you'd create a batchfile like this and set it as
+your mergetool: >
+
+    set LOCAL=%1
+    set REMOTE=%2
+    set BASE=%3
+    set MERGED=%4
+    gvim --nofork -c "let g:mergetool_args_order = 'MBLR'" -c "Merge" "%MERGED%" "%BASE%" "%LOCAL%" "%REMOTE%"
+<
+                                                  *mergetool-exiting*
+
+When exiting merge mode, mergetool would prompt you whether merge was
+successful. If not, it will rollback changes to the buffer, will not save
+`MERGED` file to disk, and exit with non-zero code, when running as a git
+mergetool.
+
+You can either issue `:MergetoolStop` or `:MergetoolToggle` commands, or use
+dedicated mapping.
+
+Yet another approach, which I prefer in my personal `vimrc`, is having a
+`<leader>q` key mapped to context-aware `QuitWindow()` function. It detects
+whether we're in merge mode, and runs `:MergetoolStop` command, or just uses
+normal "quit" command otherwise. >
+
+  function s:QuitWindow()
+
+    " If we're in merge mode, exit
+    if get(g:, 'mergetool_in_merge_mode', 0)
+      call mergetool#stop()
+      return
+    endif
+
+    if &diff
+      " Quit diff mode intelligently...
+    endif
+
+    quit
+  endfunction
+
+  command! QuitWindow call s:QuitWindow()
+  nnoremap <silent> <leader>q :QuitWindow<CR>
+<
+===============================================================================
+vim:tw=78:sw=2:ts=2:ft=help:norl:nowrap:

--- a/plugin/mergetool.vim
+++ b/plugin/mergetool.vim
@@ -7,6 +7,7 @@ let g:loaded_mergetool = 1
 
 let g:mergetool_in_merge_mode = 0
 
+" Commands and <plug> mappings for mergetool state
 command! -nargs=0 MergetoolStart call mergetool#start()
 command! -nargs=0 MergetoolStop call mergetool#stop()
 command! -nargs=0 MergetoolToggle call mergetool#toggle()
@@ -17,64 +18,17 @@ command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
 
 nnoremap <silent> <Plug>(MergetoolToggle) :<C-u>call mergetool#toggle()<CR>
 
-" {{{ Diff exchange
 
-" Do either diffget or diffput, depending on given direction
-" and whether the window has adjacent window in a given direction
-" h|<left> + window on right = diffget from right win
-" h|<left> + no window on right = diffput to left win
-" l|<right> + window on left = diffget from left win
-" l|<right> + no window on left = diffput to right win
-" Same logic applies for vertical directions: 'j' and 'k'
-
-let s:directions = {
-      \ 'h': 'l',
-      \ 'l': 'h',
-      \ 'j': 'k',
-      \ 'k': 'j' }
-
-function s:DiffExchange(dir)
-  let oppdir = s:directions[a:dir]
-
-  let winoppdir = s:FindWindowOnDir(oppdir)
-  if (winoppdir != -1)
-    execute "diffget " . winbufnr(winoppdir)
-  else
-    let windir = s:FindWindowOnDir(a:dir)
-    if (windir != -1)
-      execute "diffput " . winbufnr(windir)
-    else
-      echohl WarningMsg
-      echo 'Cannot exchange diff. Found only single window'
-      echohl None
-    endif
-  endif
-endfunction
-
-" Finds window in given direction and returns it win number
-" If no window found, returns -1
-function s:FindWindowOnDir(dir)
-  let oldwin = winnr()
-
-  execute "noautocmd wincmd " . a:dir
-  let curwin = winnr()
-  if (oldwin != curwin)
-    noautocmd wincmd p
-    return curwin
-  else
-    return -1
-  endif
-endfunction
 
 " Commands and <plug> mappings for diff exchange commands
-command! -nargs=0 MergetoolDiffExchangeLeft call s:DiffExchange('h')
-command! -nargs=0 MergetoolDiffExchangeRight call s:DiffExchange('l')
-command! -nargs=0 MergetoolDiffExchangeDown call s:DiffExchange('j')
-command! -nargs=0 MergetoolDiffExchangeUp call s:DiffExchange('k')
+command! -nargs=0 MergetoolDiffExchangeLeft call mergetool#DiffExchange('h')
+command! -nargs=0 MergetoolDiffExchangeRight call mergetool#DiffExchange('l')
+command! -nargs=0 MergetoolDiffExchangeDown call mergetool#DiffExchange('j')
+command! -nargs=0 MergetoolDiffExchangeUp call mergetool#DiffExchange('k')
 
-nnoremap <silent> <Plug>(MergetoolDiffExchangeLeft) :<C-u>call <SID>DiffExchange('h')<CR>
-nnoremap <silent> <Plug>(MergetoolDiffExchangeRight) :<C-u>call <SID>DiffExchange('l')<CR>
-nnoremap <silent> <Plug>(MergetoolDiffExchangeDown) :<C-u>call <SID>DiffExchange('j')<CR>
-nnoremap <silent> <Plug>(MergetoolDiffExchangeUp) :<C-u>call <SID>DiffExchange('k')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeLeft) :<C-u>call mergetool#DiffExchange('h')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeRight) :<C-u>call mergetool#DiffExchange('l')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeDown) :<C-u>call mergetool#DiffExchange('j')<CR>
+nnoremap <silent> <Plug>(MergetoolDiffExchangeUp) :<C-u>call mergetool#DiffExchange('k')<CR>
 
 " }}}

--- a/plugin/mergetool.vim
+++ b/plugin/mergetool.vim
@@ -7,20 +7,17 @@ let g:loaded_mergetool = 1
 
 let g:mergetool_in_merge_mode = 0
 
-" Commands and <plug> mappings for mergetool state
+" Commands and <plug> mappings for mergetool state. Additional commands
+" available during merging.
 command! -nargs=0 MergetoolStart call mergetool#start()
-command! -nargs=0 MergetoolStop call mergetool#stop()
 command! -nargs=0 MergetoolToggle call mergetool#toggle()
-command! -nargs=1 MergetoolSetLayout call mergetool#set_layout(<f-args>)
-command! -nargs=1 MergetoolToggleLayout call mergetool#toggle_layout(<f-args>)
-command! -nargs=0 MergetoolPreferLocal call mergetool#prefer_revision('local')
-command! -nargs=0 MergetoolPreferRemote call mergetool#prefer_revision('remote')
 
 nnoremap <silent> <Plug>(MergetoolToggle) :<C-u>call mergetool#toggle()<CR>
 
 
 
-" Commands and <plug> mappings for diff exchange commands
+" Commands and <plug> mappings for diff exchange commands. These can be used
+" outside of merging (in any diff windows).
 command! -nargs=0 MergetoolDiffExchangeLeft call mergetool#DiffExchange('h')
 command! -nargs=0 MergetoolDiffExchangeRight call mergetool#DiffExchange('l')
 command! -nargs=0 MergetoolDiffExchangeDown call mergetool#DiffExchange('j')

--- a/readme.md
+++ b/readme.md
@@ -383,6 +383,18 @@ let g:airline_section_z = airline#section#create(['_diffmerge', ...other_parts])
 
 ![Status line indicator](./screenshots/airline_merge_indicator.png)
 
+
+You can run vimscript when mergemode begins and ends:
+
+```vim
+augroup your_mergetool
+  au!
+  autocmd User MergetoolStart set nospell
+  autocmd User MergetoolStop set spell
+augroup END
+```
+
+
 ### Quitting merge mode
 
 When exiting merge mode, `vim-mergetool` would prompt you whether merge was successful. If not, it will rollback changes to the buffer, will not save `MERGED` file to disk, and exit with non-zero code, when running as a `git mergetool`.

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ Alternatively, you can start with `local` or `unmodified` revision, and change y
 
 ### Layout
 
-`vim-mergetool` defaults to two vertical splits layout with `MERGED` file on the left, and `remote` revision on the right. `MERGED` file is processed according to `g:mergetool_prefer_revision` setting as described above.
+`vim-mergetool` defaults to two vertical splits layout with `MERGED` file on the left and `remote` revision on the right. `MERGED` file is processed according to `g:mergetool_prefer_revision` setting as described above.
 
 ```vim
 " (m) - for working tree version of MERGED file
@@ -152,7 +152,7 @@ let g:mergetool_layout = 'bmr'
 
 ![3 way diff vertical split layout](./screenshots/bmr_3splits_layout.png)
 
-To show usual `REMOTE`, `LOCAL`, `BASE` history revisions, use uppercase characters:
+Lower case letters use files derived from the merged file (by accepting that file's view of conflicts). To use the original `REMOTE`, `LOCAL`, `BASE` files from git, use uppercase characters:
 
 ```vim
 let g:mergetool_layout = 'LmR'
@@ -160,7 +160,7 @@ let g:mergetool_layout = 'LmR'
 
 By the way, this setup is pretty much same to what [vim-fugitive](https://github.com/tpope/vim-fugitive) `:Gdiff` does, except that conflict markers are already removed. You can use `g:mergetool_prefer_revision='unmodified'` to replicate vim-fugitive completely. Indeed, `vim-mergetool` is flexible enough to replicate any existing vim+merge solution.
 
-Vertical splits are used by default. If you prefer working with horizontal splits:
+Vertical splits are used by default. Use a comma to split horizontally:
 
 ```vim
 let g:mergetool_layout = 'm,r'
@@ -182,8 +182,7 @@ For example, you can start with 2-way diff layout, and then temporarily toggle a
 
 
 ```vim
-" In 'vimrc'
-" Default layout
+" In 'vimrc', set your default layout.
 let g:mergetool_layout = 'mr'
 
 " Later, during merge process:
@@ -277,13 +276,13 @@ Git detects whether merge was successful or not in two ways:
 
 ### Running as other scm mergetool
 
-You can set the g:mergetool_args_order variable when you start vim to tell vim-mergetool that your arguments are the files to use for merging. Setup your scm to start vim like this:
+If your scm doesn't use files called `BASE`, `REMOTE`, `LOCAL` as merge tempfiles (like svn), you can set the g:mergetool_args_order variable to tell mergetool which argument is which file. Setup your scm to start vim like this:
 
     gvim --nofork -c "let g:mergetool_args_order = 'MBRL'" -c "MergetoolStart" $MERGED $BASE $REMOTE $LOCAL
 
 **MERGED should be the first file** because MergetoolStart is only valid in a file with conflict markers.
 
-Your scm likely has its own names for these filenames. Check your documentation.
+Your scm likely has its own variable names for these filenames. Check your documentation.
 
 
 #### Example: Subversion
@@ -325,7 +324,7 @@ You can set up a key mapping to toggle merge mode:
 nmap <leader>mt <plug>(MergetoolToggle)
 ```
 
-When exiting merge mode, if merge was unsuccessful, `vim-mergetool` would discard changes to merged file and rollback to a buffer state as it were right before starting a new merge.
+When exiting merge mode, if merge was unsuccessful, `vim-mergetool` discards changes to merged file and rollback to a buffer state as it were right before starting a new merge.
 
 Unlike running as a `git mergetool`, `LOCAL`, `REMOTE` and `BASE` history revisions are not passed from the outside. In this mode, `vim-mergetool` extracts them from the numbered stages of Git index.
 
@@ -378,7 +377,7 @@ If the rightmost split were the active one:
 
 Same logic applies to "up" and "down" directions. Useful if you prefer horizontal splits.
 
-**Conclusion**: despite how many splits are opened and what's the layout, you don't need to wrap your head around `diffput` vs `diffget` semantics, and you don't need to figure out correct buffer numbers manually. You just tell desired diff movement direction, and `vim-mergetool` handles the details for you.
+**Conclusion**: despite how many splits are opened and what's the layout, you don't need to wrap your head around `diffput` vs `diffget` semantics, and you don't need to figure out correct buffer numbers manually. You just give desired diff movement direction, and `vim-mergetool` handles the details for you.
 
 **Limitation**: `DiffExchange` commands work only in normal mode, and do not support visual mode and working with line ranges.
 
@@ -387,8 +386,8 @@ Same logic applies to "up" and "down" directions. Useful if you prefer horizonta
 If you like `<C-arrow>` mappings from the snippet above, you might also want to map `<up>` and `<down>` keys to navigate diffs, instead of default `[c` and `]c` mappings. They're not used anyway, since you're using `h,j,k,l` for movements, are you? ;-)
 
 ```vim
-nmap <expr> <Up> &diff ? '[c' : '<Up>'
-nmap <expr> <Down> &diff ? ']c' : '<Down>'
+nnoremap <expr> <Up> &diff ? '[c' : '<Up>'
+nnoremap <expr> <Down> &diff ? ']c' : '<Down>'
 ```
 
 
@@ -456,7 +455,7 @@ function s:QuitWindow()
   quit
 endfunction
 
-command QuitWindow call s:QuitWindow()
+command! QuitWindow call s:QuitWindow()
 nnoremap <silent> <leader>q :QuitWindow<CR>
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,41 @@ Git detects whether merge was successful or not in two ways:
 `vim-mergetool` supports both options. On quit, if merge was unsuccessful,  it both discards any unsaved changes to buffer without touching file's `ctime` and returns non-zero exit code.
 
 
+### Running as other scm mergetool
+
+You can set the g:mergetool_args_order variable when you start vim to tell vim-mergetool that your arguments are the files to use for merging. Setup your scm to start vim like this:
+
+    gvim --nofork -c "let g:mergetool_args_order = 'MBRL'" -c "MergetoolStart" $MERGED $BASE $REMOTE $LOCAL
+
+**MERGED should be the first file** because MergetoolStart is only valid in a file with conflict markers.
+
+Your scm likely has its own names for these filenames. Check your documentation.
+
+
+#### Example: Subversion
+
+Subversion names the files something like this:
+
+* MERGED --> file.vim
+* BASE --> file.vim.r404217
+* REMOTE --> file.vim.r404563
+* LOCAL --> file.vim.mine
+
+So you'd start a merge like this:
+
+    gvim --nofork -c "let g:mergetool_args_order = 'MBRL'" -c "MergetoolStart" file.vim file.vim.r404217 file.vim.r404563 file.vim.mine
+
+vim-mergetool will act like it does as a git-mergetool (no extra tab and won't try to access git to load other files).
+
+For TortoiseSVN, create a batchfile like this and set it as your mergetool:
+
+    set LOCAL=%1
+    set REMOTE=%2
+    set BASE=%3
+    set MERGED=%4
+    gvim --nofork -c "let g:mergetool_args_order = 'MBLR'" -c "Merge" "%MERGED%" "%BASE%" "%LOCAL%" "%REMOTE%"
+
+
 ### Running directly from running Vim instance
 You can enter and exit merge mode from running Vim instance by opening a file with conflict markers, and running one of the commands:
 


### PR DESCRIPTION
This PR isn't really mergeable because it's based on a bunch of my other PRs. Since they touched readme, it's not worth it to disentangle them. But if you merge them, I can clean it up for merging.

Only the last two commits are relevant.

I did this because I occasionally try to look up help for mergetool and am annoyed to find nothing and have to browse the readme (which doesn't have intra document links).

- Mostly copied verbatim. Moved some sections around to be more logical
within vimdoc.
- Rephrased some bits and applied the same rephrasing to readme.
- Removed some sections that weren't relevant to people already using from
within vim.
- Lots of line wrapping and converting `` to || or other corresponding
help markup.

Second commit strips down readme to reduce (but not eliminate) duplication. Readme has lots of pictures and I didn't want to remove those.